### PR TITLE
Add Support for Azure TokenCredential Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Log.Logger = new LoggerConfiguration()
                 )
                 .CreateLogger();
 ```
+Alternatively, you can use an Azure.Core.TokenCredential object to authenticate instead of an authorization key
+
+```C#
+Log.Logger = new LoggerConfiguration()
+                .WriteTo.AzureCosmosDB(
+                    endpointUri: <uri>,
+                    tokenCredential: <token credential>,
+                    partitionKey: "MyCustomKeyName"
+                )
+                .CreateLogger();
+```
 
 ## IPartitionKeyProvider
 The DefaultPartitionkeyProvide will generate a utc date string with the format "dd.MM.yyyy". If you want to override it, you need to define a class and implement IPartitionKeyProvider interface and pass an instance of it in the arguments list.

--- a/src/LoggerConfigurationAzureCosmosDbExtensions.cs
+++ b/src/LoggerConfigurationAzureCosmosDbExtensions.cs
@@ -18,6 +18,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.AzureCosmosDB;
 using Serilog.Sinks.PeriodicBatching;
+using Azure.Core;
 
 namespace Serilog
 {
@@ -32,7 +33,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="endpointUri">The endpoint URI of the document db.</param>
-        /// <param name="authorizationKey">The authorization key of the db.</param>
+        /// <param name="authorizationKey">The authorization key of the db. Use this or tokenCredential. tokenCredential has precedence.</param>
+        /// <param name="tokenCredential">The Azure TokenCredential for cosmos access. Use this or authorizationKey. This has precedence.</param>
         /// <param name="databaseName">The name of the database to use; will create if it doesn't exist.</param>
         /// <param name="collectionName">The name of the collection to use inside the database; will created if it doesn't exist.</param>
         /// <param name="partitionKey">The name of partition key for the collection.</param>
@@ -54,10 +56,11 @@ namespace Serilog
         public static LoggerConfiguration AzureCosmosDB(
             this LoggerSinkConfiguration loggerConfiguration,
             Uri endpointUri,
-            string authorizationKey,
+            string authorizationKey = null,
+            TokenCredential tokenCredential = null,
             string databaseName = "Diagnostics",
             string collectionName = "Logs",
-            string partitionKey = "UtcDate",
+            string partitionKey = "UtcDate", 
             IPartitionKeyProvider partitionKeyProvider = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             IFormatProvider formatProvider = null,
@@ -96,6 +99,7 @@ namespace Serilog
                 PartitionKey = partitionKey,
                 FormatProvider = formatProvider,
                 AuthorizationKey = authorizationKey,
+                TokenCredential = tokenCredential,
                 BatchPostingLimit = batchSize,
                 CollectionName = collectionName,
                 DatabaseName = databaseName,
@@ -127,7 +131,8 @@ namespace Serilog
         /// </summary>
         /// <param name="loggerConfiguration">The logger configuration.</param>
         /// <param name="endpointUrl">The endpoint url of the document db.</param>
-        /// <param name="authorizationKey">The authorization key of the db.</param>
+        /// <param name="authorizationKey">The authorization key of the db. Use this or tokenCredential. tokenCredential has precedence.</param>
+        /// <param name="tokenCredential">The Azure TokenCredential for cosmos access. Use this or authorizationKey. This has precedence.</param>
         /// <param name="databaseName">The name of the database to use; will create if it doesn't exist.</param>
         /// <param name="collectionName">The name of the collection to use inside the database; will created if it doesn't exist.</param>
         /// <param name="partitionKey">The name of partition key for the collection.</param>
@@ -146,7 +151,8 @@ namespace Serilog
         public static LoggerConfiguration AzureCosmosDB(
             this LoggerSinkConfiguration loggerConfiguration,
             Uri endpointUrl,
-            string authorizationKey,
+            string authorizationKey = null,
+            TokenCredential tokenCredential = null,
             string databaseName = "Diagnostics",
             string collectionName = "Logs",
             string partitionKey = "UtcDate",
@@ -169,9 +175,9 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(endpointUrl));
             }
 
-            if (authorizationKey == null)
+            if (authorizationKey == null && tokenCredential == null)
             {
-                throw new ArgumentNullException(nameof(authorizationKey));
+                throw new ArgumentNullException(nameof(authorizationKey), $"{nameof(authorizationKey)} and {nameof(tokenCredential)} cannot both be null!");
             }
 
             if ((timeToLive != null) && (timeToLive.Value > TimeSpan.FromDays(24_855).TotalSeconds))
@@ -191,6 +197,7 @@ namespace Serilog
                 PartitionKey = partitionKey,
                 FormatProvider = formatProvider,
                 AuthorizationKey = authorizationKey,
+                TokenCredential = tokenCredential,
                 BatchPostingLimit = batchSize,
                 CollectionName = collectionName,
                 DatabaseName = databaseName,
@@ -232,9 +239,9 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(options.EndpointUri));
             }
 
-            if (string.IsNullOrWhiteSpace(options.AuthorizationKey))
+            if (string.IsNullOrWhiteSpace(options.AuthorizationKey) && options.TokenCredential == null)
             {
-                throw new ArgumentNullException(nameof(options.AuthorizationKey));
+                throw new ArgumentNullException(nameof(options.AuthorizationKey), $"{nameof(options.AuthorizationKey)} and {nameof(options.TokenCredential)} cannot both be null!");
             }
 
             if ((options.TimeToLive != null) && (options.TimeToLive.Value.TotalSeconds > TimeSpan.FromDays(24_855).TotalSeconds))

--- a/src/Sinks/AzureCosmosDb/AzureCosmosDbSink.cs
+++ b/src/Sinks/AzureCosmosDb/AzureCosmosDbSink.cs
@@ -73,10 +73,20 @@ namespace Serilog.Sinks.AzureCosmosDB
                 }
              };
 
-            _client = new CosmosClientBuilder(options.EndpointUri.ToString(), options.AuthorizationKey)
-              .WithCustomSerializer(new NewtonsoftJsonCosmosSerializer(serializerSettings))
-              .WithConnectionModeGateway()
-              .Build();
+            if (options.TokenCredential != null)
+            {
+                _client = new CosmosClientBuilder(options.EndpointUri.ToString(), options.TokenCredential)
+                  .WithCustomSerializer(new NewtonsoftJsonCosmosSerializer(serializerSettings))
+                  .WithConnectionModeGateway()
+                  .Build();
+            }
+            else
+            {
+                _client = new CosmosClientBuilder(options.EndpointUri.ToString(), options.AuthorizationKey)
+                  .WithCustomSerializer(new NewtonsoftJsonCosmosSerializer(serializerSettings))
+                  .WithConnectionModeGateway()
+                  .Build();
+            }
             
             CreateDatabaseAndContainerIfNotExistsAsync(options.DatabaseName, options.CollectionName, options.PartitionKey).Wait();
         }

--- a/src/Sinks/AzureCosmosDb/AzureCosmosDbSinkOptions.cs
+++ b/src/Sinks/AzureCosmosDb/AzureCosmosDbSinkOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Azure.Core;
 
 namespace Serilog.Sinks.AzureCosmosDB
 {
@@ -32,7 +33,12 @@ namespace Serilog.Sinks.AzureCosmosDB
         }
 
         public Uri EndpointUri { get; set; }
+        /// <summary>
+        /// Note: If TokenCredential is not null, it will be used to authenticate over the
+        /// AuthorizationKey. 
+        /// </summary>
         public string AuthorizationKey { get; set; }
+        public TokenCredential TokenCredential { get; set; }
         public string DatabaseName { get; set; }
         public string CollectionName { get; set; }
         public string PartitionKey { get; set; }


### PR DESCRIPTION
My organization requires the use of identity-based authentication instead of a simple authorization key when working with cosmos. This is one possible implementation meeting these requirements.

One thing to note is that the signature of the AzureCosmosDb factory method has been altered to take a TokenCredential as well as an authorization key, with both having defaults of null. So, anyone using the default values for everything, and just the old required positional parameters should have no issues. However, if someone was using passing arguments positionally after authorizationKey, this would be a breaking change. However, the alternative is to pass in the TokenCredential argument at the very end of the method, which feels very unnatural. 